### PR TITLE
ITKImportImageStack filter "fail fast" on preflight when validating files

### DIFF
--- a/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKImportImageStack.cpp
+++ b/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKImportImageStack.cpp
@@ -158,7 +158,7 @@ IFilter::PreflightResult ITKImportImageStack::preflightImpl(const DataStructure&
   auto imageGeomPath = filterArgs.value<DataPath>(k_ImageGeometryPath_Key);
   auto imageDataPath = filterArgs.value<DataPath>(k_ImageDataArrayPath_Key);
 
-  std::vector<std::string> files = inputFileListInfo.generate(true).first;
+  std::vector<std::string> files = inputFileListInfo.generate();
 
   if(files.empty())
   {
@@ -220,7 +220,7 @@ Result<> ITKImportImageStack::executeImpl(DataStructure& dataStructure, const Ar
   auto imageGeomPath = filterArgs.value<DataPath>(k_ImageGeometryPath_Key);
   auto imageDataPath = filterArgs.value<DataPath>(k_ImageDataArrayPath_Key);
 
-  std::vector<std::string> files = inputFileListInfo.generate(false).first;
+  std::vector<std::string> files = inputFileListInfo.generate();
 
   const std::string& firstFile = files.at(0);
 

--- a/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKImportImageStack.cpp
+++ b/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKImportImageStack.cpp
@@ -158,7 +158,7 @@ IFilter::PreflightResult ITKImportImageStack::preflightImpl(const DataStructure&
   auto imageGeomPath = filterArgs.value<DataPath>(k_ImageGeometryPath_Key);
   auto imageDataPath = filterArgs.value<DataPath>(k_ImageDataArrayPath_Key);
 
-  std::vector<std::string> files = inputFileListInfo.generate().first;
+  std::vector<std::string> files = inputFileListInfo.generate(true).first;
 
   if(files.empty())
   {
@@ -220,7 +220,7 @@ Result<> ITKImportImageStack::executeImpl(DataStructure& dataStructure, const Ar
   auto imageGeomPath = filterArgs.value<DataPath>(k_ImageGeometryPath_Key);
   auto imageDataPath = filterArgs.value<DataPath>(k_ImageDataArrayPath_Key);
 
-  std::vector<std::string> files = inputFileListInfo.generate().first;
+  std::vector<std::string> files = inputFileListInfo.generate(false).first;
 
   const std::string& firstFile = files.at(0);
 


### PR DESCRIPTION
API update to match the feature/GeneratedFileListThreading update in complex:
ITKImageStack filter will now only generate the file list instead of generating and validating and relies on the GUI/calls to ITKImageReader to handle missing files.