### PR TITLE
ResampleImageGeometryFilter updates & unit test

### DIFF
--- a/.github-disabled/workflows/linux.yml
+++ b/.github-disabled/workflows/linux.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Download Test Files
         shell: bash
         run: >
-          wget --quiet "https://github.com/dream3d/DREAM3D_Data/releases/download/v6_9/TestFiles_6_9.tar.gz" -O ${{github.workspace}}/DREAM3D_Data/TestFiles.tar.gz
+          wget --quiet "https://github.com/dream3d/DREAM3D_Data/releases/download/v6_10/TestFiles_6_10.tar.gz" -O ${{github.workspace}}/DREAM3D_Data/TestFiles.tar.gz
       - name: Extract Test Files
         shell: bash
         run: >

--- a/.github-disabled/workflows/macos.yml
+++ b/.github-disabled/workflows/macos.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Download Test Files
         shell: bash
         run: >
-          wget --quiet "https://github.com/dream3d/DREAM3D_Data/releases/download/v6_9/TestFiles_6_9.tar.gz" -O ${{github.workspace}}/DREAM3D_Data/TestFiles.tar.gz
+          wget --quiet "https://github.com/dream3d/DREAM3D_Data/releases/download/v6_10/TestFiles_6_10.tar.gz" -O ${{github.workspace}}/DREAM3D_Data/TestFiles.tar.gz
       - name: Extract Test Files
         shell: bash
         run: >

--- a/.github-disabled/workflows/windows.yml
+++ b/.github-disabled/workflows/windows.yml
@@ -44,15 +44,15 @@ jobs:
         uses: suisei-cn/actions-download-file@v1.0.1
         id: downloadfile  # Remember to give an ID if you need the output filename
         with:
-          url: "https://github.com/dream3d/DREAM3D_Data/releases/download/v6_9/TestFiles_6_9.tar.gz"
+          url: "https://github.com/dream3d/DREAM3D_Data/releases/download/v6_10/TestFiles_6_10.tar.gz"
           target: ${{github.workspace}}/DREAM3D_Data
       - name: Find TestFiles.tar.gz
         shell: bash
         run: >
-          find . -type f -name "TestFiles_6_9.tar.gz"
+          find . -type f -name "TestFiles_6_10.tar.gz"
       - name: Decompress TestFiles
         run: |
-          cmake -E tar xvzf ${{github.workspace}}/DREAM3D_Data/TestFiles_6_9.tar.gz
+          cmake -E tar xvzf ${{github.workspace}}/DREAM3D_Data/TestFiles_6_10.tar.gz
       - name: Move TestFiles Directory into location
         run: |
           cmake -E rename ${{github.workspace}}/TestFiles ${{github.workspace}}/DREAM3D_Data/TestFiles

--- a/Core/docs/Core/ResampleImageGeom.md
+++ b/Core/docs/Core/ResampleImageGeom.md
@@ -18,7 +18,7 @@ A new grid of **Cells** is created and "overlaid" on the existing grid of **Cell
 |------|------|-------------|
 | Sapcing | float (3x) | The new resolution values (dx, dy, dz) |
 | Renumber Features | bool | Whether the **Features** should be renumbered |
-| Save as New Data Container | bool | Whether the new grid of **Cells** should replace the current **Geometry** or if a new **Data Container** should be created to hold it |
+| Remove Original Geometry | bool | Whether the current **Geometry** should be removed after the resampling |
 
 ## Required Geometry ##
 
@@ -36,7 +36,7 @@ Image
 
 | Kind | Default Name | Type | Component Dimensions | Description |
 |------|--------------|------|----------------------|-------------|
-| **Data Container** | NewImageDataContainer | N/A | N/A | Created **Data Container** name with an **Image Geometry**. Only created if _Save as New Data Container_ is checked |
+| **Data Container** | NewImageDataContainer | N/A | N/A | Created **Data Container** name with an **Image Geometry**. |
 
 ## Example Pipelines ##
 

--- a/Core/src/Core/Filters/Algorithms/ResampleImageGeom.cpp
+++ b/Core/src/Core/Filters/Algorithms/ResampleImageGeom.cpp
@@ -150,6 +150,7 @@ Result<> ResampleImageGeom::operator()()
   int32_t threadCount = 0;
 #endif
 
+  // copy over/resample the cell data
   for(const auto& cellArrayPath : selectedCellArrays)
   {
     if(m_ShouldCancel)
@@ -230,12 +231,13 @@ Result<> ResampleImageGeom::operator()()
   g->wait();
 #endif
 
+  // optionally: copy over and renumber/resize the cell feature data
   if(m_InputValues->renumberFeatures)
   {
     const AttributeMatrix* srcCellFeaturData = m_DataStructure.getDataAs<AttributeMatrix>(m_InputValues->cellFeatureAttributeMatrix);
     DataPath destCellFeaturesPath = m_InputValues->newDataContainerPath.createChildPath(m_InputValues->cellFeatureAttributeMatrix.getTargetName());
-    AttributeMatrix& cellFeaturData = m_DataStructure.getDataRefAs<AttributeMatrix>(destCellFeaturesPath);
-    for(const auto& [id, object] : cellFeaturData)
+    AttributeMatrix& cellFeatureData = m_DataStructure.getDataRefAs<AttributeMatrix>(destCellFeaturesPath);
+    for(const auto& [id, object] : cellFeatureData)
     {
       if(m_ShouldCancel)
       {
@@ -293,11 +295,6 @@ Result<> ResampleImageGeom::operator()()
     {
       return result;
     }
-  }
-
-  if(m_InputValues->removeOriginalImageGeom)
-  {
-    return MakeErrorResult(-23500, "Removing Original Geometry Group is not Implemented.");
   }
 
   return {};

--- a/Core/src/Core/Filters/Algorithms/ResampleImageGeom.cpp
+++ b/Core/src/Core/Filters/Algorithms/ResampleImageGeom.cpp
@@ -38,7 +38,7 @@ public:
   ~ChangeResolutionImpl() = default;
 
   // -----------------------------------------------------------------------------
-  void compute(size_t zStart, size_t zEnd, size_t yStart, size_t yEnd, size_t xStart, size_t xEnd) const
+  void compute(size_t xStart, size_t xEnd, size_t yStart, size_t yEnd, size_t zStart, size_t zEnd) const
   {
     for(size_t i = zStart; i < zEnd; i++)
     {

--- a/Core/src/Core/Filters/ResampleImageGeomFilter.cpp
+++ b/Core/src/Core/Filters/ResampleImageGeomFilter.cpp
@@ -173,7 +173,7 @@ IFilter::PreflightResult ResampleImageGeomFilter::preflightImpl(const DataStruct
   // These values should have been updated during the preflightImpl(...) method
   preflightUpdatedValues.push_back({"Input Geometry Info", ::GenerateGeometryInfo(oldDims, oldSpacing, oldOrigin)});
   preflightUpdatedValues.push_back(
-      {"Created Image Geometry Info", ::GenerateGeometryInfo(complex::SizeVec3(m_XP, m_YP, m_ZP), complex::FloatVec3(pSpacingValue[0], pSpacingValue[1], pSpacingValue[2]), oldOrigin)});
+      {"Resampled Image Geometry Info", ::GenerateGeometryInfo(complex::SizeVec3(m_XP, m_YP, m_ZP), complex::FloatVec3(pSpacingValue[0], pSpacingValue[1], pSpacingValue[2]), oldOrigin)});
   std::vector<std::string> cellDataArrayNames = cellDataGroup->getDataMap().getNames();
 
   usize originalImageSize = std::accumulate(oldDims.begin(), oldDims.end(), static_cast<usize>(1), std::multiplies<>{});

--- a/Core/src/Core/Filters/ResampleImageGeomFilter.cpp
+++ b/Core/src/Core/Filters/ResampleImageGeomFilter.cpp
@@ -4,7 +4,7 @@
 #include "complex/DataStructure/Geometry/ImageGeom.hpp"
 #include "complex/DataStructure/INeighborList.hpp"
 #include "complex/Filter/Actions/CopyArrayInstanceAction.hpp"
-#include "complex/Filter/Actions/CopyGroupAction.hpp"
+#include "complex/Filter/Actions/CopyDataObjectAction.hpp"
 #include "complex/Filter/Actions/CreateArrayAction.hpp"
 #include "complex/Filter/Actions/CreateAttributeMatrixAction.hpp"
 #include "complex/Filter/Actions/CreateImageGeometryAction.hpp"
@@ -252,16 +252,12 @@ IFilter::PreflightResult ResampleImageGeomFilter::preflightImpl(const DataStruct
             allCreatedPaths.push_back(DataPath::FromString(createdPathName).value());
           }
         }
-        resultOutputActions.value().actions.push_back(std::make_unique<CopyGroupAction>(childPath, copiedChildPath, allCreatedPaths));
+        resultOutputActions.value().actions.push_back(std::make_unique<CopyDataObjectAction>(childPath, copiedChildPath, allCreatedPaths));
       }
-      else if(dataStructure.getDataAs<IDataArray>(childPath) != nullptr)
+      else
       {
-        resultOutputActions.value().actions.push_back(std::make_unique<CopyArrayInstanceAction>(childPath, copiedChildPath));
+        resultOutputActions.value().actions.push_back(std::make_unique<CopyDataObjectAction>(childPath, copiedChildPath, std::vector<DataPath>{copiedChildPath}));
       }
-      // TODO : copy neighborlist
-      // TODO : copy string array
-      // TODO : copy scalar data
-      // TODO : copy dynamic list array
     }
   }
 

--- a/Core/src/Core/Filters/ResampleImageGeomFilter.cpp
+++ b/Core/src/Core/Filters/ResampleImageGeomFilter.cpp
@@ -1,6 +1,5 @@
 #include "ResampleImageGeomFilter.hpp"
 
-#include "complex/DataStructure/DataGroup.hpp"
 #include "complex/DataStructure/DataPath.hpp"
 #include "complex/DataStructure/Geometry/ImageGeom.hpp"
 #include "complex/DataStructure/INeighborList.hpp"
@@ -96,8 +95,6 @@ Parameters ResampleImageGeomFilter::parameters() const
   params.insertSeparator(Parameters::Separator{"Created Image Geometry"});
   params.insert(
       std::make_unique<DataGroupCreationParameter>(k_NewDataContainerPath_Key, "Resampled Image Geometry", "Location to store the resampled image geometry", DataPath({"Resampled Image Geometry"})));
-  // params.insert(std::make_unique<StringParameter>(k_NewFeaturesName_Key, "New Cell Features Group Name", "Name of the new DataGroup containing updated Voxel Arrays", "Cell Features"));
-
   return params;
 }
 

--- a/Core/src/Core/Filters/ResampleImageGeomFilter.hpp
+++ b/Core/src/Core/Filters/ResampleImageGeomFilter.hpp
@@ -31,7 +31,6 @@ public:
   static inline constexpr StringLiteral k_CellFeatureAttributeMatrixPath_Key = "CellFeatureAttributeMatrixPath";
   static inline constexpr StringLiteral k_NewDataContainerPath_Key = "NewDataContainerPath";
   static inline constexpr StringLiteral k_SelectedImageGeometry_Key = "selected_image_geometry";
-  static inline constexpr StringLiteral k_NewFeaturesName_Key = "new_features_group_name";
 
   /**
    * @brief Returns the name of the filter.

--- a/Core/test/CMakeLists.txt
+++ b/Core/test/CMakeLists.txt
@@ -13,7 +13,7 @@ set(${PLUGIN_NAME}UnitTest_SRCS
   FillBadDataTest.cpp # NEEDS TEST IMPLEMENTED
   FindFeatureCentroidsFilterTest.cpp
   FindShapesFilterTest.cpp
-  ResampleImageGeomFilterTest.cpp # NEEDS TEST IMPLEMENTED
+  ResampleImageGeomFilterTest.cpp
   RotateSampleRefFrameTest.cpp
   ErodeDilateBadDataTest.cpp
   WriteASCIIDataTest.cpp

--- a/Core/test/ResampleImageGeomFilterTest.cpp
+++ b/Core/test/ResampleImageGeomFilterTest.cpp
@@ -41,7 +41,7 @@ TEST_CASE("Core::ResampleImageGeom: Instantiation and Parameter Check", "[Sampli
   // Create default Parameters for the filter.
   args.insertOrAssign(ResampleImageGeomFilter::k_Spacing_Key, std::make_any<VectorFloat32Parameter::ValueType>(std::vector<float32>(3)));
   args.insertOrAssign(ResampleImageGeomFilter::k_RenumberFeatures_Key, std::make_any<bool>(false));
-  // args.insertOrAssign(ResampleImageGeomFilter::k_RemoveOriginalGeometry_Key, std::make_any<bool>(false));
+  args.insertOrAssign(ResampleImageGeomFilter::k_RemoveOriginalGeometry_Key, std::make_any<bool>(false));
   args.insertOrAssign(ResampleImageGeomFilter::k_SelectedImageGeometry_Key, std::make_any<DataPath>(DataPath{}));
   args.insertOrAssign(ResampleImageGeomFilter::k_FeatureIdsArrayPath_Key, std::make_any<DataPath>(DataPath{}));
   args.insertOrAssign(ResampleImageGeomFilter::k_CellFeatureAttributeMatrixPath_Key, std::make_any<DataPath>(DataPath{}));

--- a/Core/test/ResampleImageGeomFilterTest.cpp
+++ b/Core/test/ResampleImageGeomFilterTest.cpp
@@ -22,46 +22,220 @@
 
 #include <catch2/catch.hpp>
 
-#include "complex/Parameters/ArraySelectionParameter.hpp"
-#include "complex/Parameters/BoolParameter.hpp"
 #include "complex/Parameters/VectorParameter.hpp"
+#include "complex/UnitTest/UnitTestCommon.hpp"
+#include "complex/Utilities/DataGroupUtilities.hpp"
+#include "complex/Utilities/FilterUtilities.hpp"
 
 #include "Core/Core_test_dirs.hpp"
 #include "Core/Filters/ResampleImageGeomFilter.hpp"
+#include "complex_plugins/Utilities/TestUtilities.hpp"
 
+#include <filesystem>
+
+namespace fs = std::filesystem;
 using namespace complex;
 
-TEST_CASE("Core::ResampleImageGeom: Instantiation and Parameter Check", "[Sampling][ResampleImageGeom][.][UNIMPLEMENTED][!mayfail]")
+struct CompareDataArrayFunctor
 {
-  // Instantiate the filter, a DataStructure object and an Arguments Object
-  ResampleImageGeomFilter filter;
-  DataStructure ds;
-  Arguments args;
+  template <typename T>
+  void operator()(const IDataArray& left, const IDataArray& right, usize start = 0)
+  {
+    UnitTest::CompareDataArrays<T>(left, right, start);
+  }
+};
 
-  // Create default Parameters for the filter.
-  args.insertOrAssign(ResampleImageGeomFilter::k_Spacing_Key, std::make_any<VectorFloat32Parameter::ValueType>(std::vector<float32>(3)));
-  args.insertOrAssign(ResampleImageGeomFilter::k_RenumberFeatures_Key, std::make_any<bool>(false));
-  args.insertOrAssign(ResampleImageGeomFilter::k_RemoveOriginalGeometry_Key, std::make_any<bool>(false));
-  args.insertOrAssign(ResampleImageGeomFilter::k_SelectedImageGeometry_Key, std::make_any<DataPath>(DataPath{}));
-  args.insertOrAssign(ResampleImageGeomFilter::k_FeatureIdsArrayPath_Key, std::make_any<DataPath>(DataPath{}));
-  args.insertOrAssign(ResampleImageGeomFilter::k_CellFeatureAttributeMatrixPath_Key, std::make_any<DataPath>(DataPath{}));
-  args.insertOrAssign(ResampleImageGeomFilter::k_NewDataContainerPath_Key, std::make_any<DataPath>(DataPath{}));
+TEST_CASE("Core::ResampleImageGeom: Instantiation, Parameter Check and valid filter execution", "[Core][ResampleImageGeom]")
+{
+  // 3D image geom
+  {
+    ResampleImageGeomFilter filter;
+    Arguments args;
 
-  // Preflight the filter and check result
-  auto preflightResult = filter.preflight(ds, args);
-  REQUIRE(preflightResult.outputActions.valid());
+    DataStructure ds = LoadDataStructure(fs::path(fmt::format("{}/TestFiles/ResampleImageGeom_Exemplar.dream3d", unit_test::k_DREAM3DDataDir)));
+    DataPath srcGeomPath({Constants::k_SmallIN100});
+    DataPath cellDataPath = srcGeomPath.createChildPath(Constants::k_EbsdScanData);
+    DataPath cellFeatureDataPath = srcGeomPath.createChildPath(Constants::k_FeatureGroupName);
+    DataPath featureIdsPath = cellDataPath.createChildPath(Constants::k_FeatureIds);
+    DataPath destGeomPath({Constants::k_SmallIN100.str() + "_RESAMPLED"});
+    DataPath destCellDataPath = destGeomPath.createChildPath(Constants::k_EbsdScanData);
+    DataPath destCellFeatureDataPath = destGeomPath.createChildPath(Constants::k_FeatureGroupName);
+    DataPath destNewGrainDataPath = destGeomPath.createChildPath("NewGrain Data");
+    DataPath destPhaseDataPath = destGeomPath.createChildPath("Phase Data");
+    DataPath exemplarGeoPath({"Resampled_3D_ImageGeom"});
+    DataPath exemplarCellDataPath = exemplarGeoPath.createChildPath(Constants::k_EbsdScanData);
+    DataPath exemplarCellFeatureDataPath = exemplarGeoPath.createChildPath(Constants::k_FeatureGroupName);
 
-  // Execute the filter and check the result
-  auto executeResult = filter.execute(ds, args);
-  REQUIRE(executeResult.result.valid());
+    // Create default Parameters for the filter.
+    args.insertOrAssign(ResampleImageGeomFilter::k_Spacing_Key, std::make_any<VectorFloat32Parameter::ValueType>(std::vector<float32>{1, 1, 1}));
+    args.insertOrAssign(ResampleImageGeomFilter::k_RenumberFeatures_Key, std::make_any<bool>(true));
+    args.insertOrAssign(ResampleImageGeomFilter::k_RemoveOriginalGeometry_Key, std::make_any<bool>(false));
+    args.insertOrAssign(ResampleImageGeomFilter::k_SelectedImageGeometry_Key, std::make_any<DataPath>(srcGeomPath));
+    args.insertOrAssign(ResampleImageGeomFilter::k_FeatureIdsArrayPath_Key, std::make_any<DataPath>(featureIdsPath));
+    args.insertOrAssign(ResampleImageGeomFilter::k_CellFeatureAttributeMatrixPath_Key, std::make_any<DataPath>(cellFeatureDataPath));
+    args.insertOrAssign(ResampleImageGeomFilter::k_NewDataContainerPath_Key, std::make_any<DataPath>(destGeomPath));
+
+    // Preflight the filter and check result
+    auto preflightResult = filter.preflight(ds, args);
+    COMPLEX_RESULT_REQUIRE_VALID(preflightResult.outputActions)
+
+    // Execute the filter and check the result
+    auto executeResult = filter.execute(ds, args);
+    COMPLEX_RESULT_REQUIRE_VALID(executeResult.result)
+
+    // check that the geometry(s) and the attribute matrixes are all there
+    const auto srcGeo = ds.getDataAs<ImageGeom>(srcGeomPath);
+    const auto destGeo = ds.getDataAs<ImageGeom>(destGeomPath);
+    const auto destCellData = ds.getDataAs<AttributeMatrix>(destCellDataPath);
+    const auto destFeatureData = ds.getDataAs<AttributeMatrix>(destCellFeatureDataPath);
+    const auto destNewGrainData = ds.getDataAs<AttributeMatrix>(destNewGrainDataPath);
+    const auto destPhaseData = ds.getDataAs<AttributeMatrix>(destPhaseDataPath);
+    const auto exemplarGeo = ds.getDataAs<ImageGeom>(exemplarGeoPath);
+    const auto exemplarCellData = ds.getDataAs<AttributeMatrix>(exemplarCellDataPath);
+    const auto exemplarFeatureData = ds.getDataAs<AttributeMatrix>(exemplarCellFeatureDataPath);
+    REQUIRE(srcGeo != nullptr);
+    REQUIRE(destGeo != nullptr);
+    REQUIRE(destCellData != nullptr);
+    REQUIRE(destFeatureData != nullptr);
+    REQUIRE(destNewGrainData != nullptr);
+    REQUIRE(destPhaseData != nullptr);
+
+    // check the resampled geometry dimensions
+    const auto destSpacing = destGeo->getSpacing();
+    const auto destDims = destGeo->getDimensions();
+    const auto destCellDataDims = destCellData->getShape();
+    const auto destFeatDataDims = destFeatureData->getShape();
+    const auto destNewGrainDataDims = destNewGrainData->getShape();
+    const auto destPhaseDataDims = destPhaseData->getShape();
+
+    const auto exemplarSpacing = exemplarGeo->getSpacing();
+    const auto exemplarDims = exemplarGeo->getDimensions();
+    const auto exemplarCellDataDims = exemplarCellData->getShape();
+    const auto exemplarFeatDataDims = exemplarFeatureData->getShape();
+    REQUIRE(exemplarGeo->getOrigin() == destGeo->getOrigin());
+    REQUIRE(std::fabs(destSpacing[0] - exemplarSpacing[0]) < UnitTest::EPSILON);
+    REQUIRE(std::fabs(destSpacing[1] - exemplarSpacing[1]) < UnitTest::EPSILON);
+    REQUIRE(std::fabs(destSpacing[2] - exemplarSpacing[2]) < UnitTest::EPSILON);
+    REQUIRE(destDims[0] == exemplarDims[0]);
+    REQUIRE(destDims[1] == exemplarDims[1]);
+    REQUIRE(destDims[2] == exemplarDims[2]);
+    REQUIRE(destCellDataDims[0] == exemplarCellDataDims[0]);
+    REQUIRE(destCellDataDims[1] == exemplarCellDataDims[1]);
+    REQUIRE(destCellDataDims[2] == exemplarCellDataDims[2]);
+    REQUIRE(destFeatDataDims[0] == 214);
+    REQUIRE(destNewGrainDataDims[0] == 5120);
+    REQUIRE(destPhaseDataDims[0] == 2);
+    REQUIRE(destCellData->getSize() == exemplarCellData->getSize());
+    REQUIRE(destFeatureData->getSize() == exemplarFeatureData->getSize());
+    REQUIRE(destNewGrainData->getSize() == 1);
+    REQUIRE(destPhaseData->getSize() == 2);
+
+    // check the data arrays
+    const auto exemplarCellDataArrays = GetAllChildArrayDataPaths(ds, exemplarCellDataPath).value();
+    const auto calculatedCellDataArrays = GetAllChildArrayDataPaths(ds, destCellDataPath).value();
+    for(usize i = 0; i < exemplarCellDataArrays.size(); ++i)
+    {
+      const IDataArray& exemplarArray = ds.getDataRefAs<IDataArray>(exemplarCellDataArrays[i]);
+      const IDataArray& calculatedArray = ds.getDataRefAs<IDataArray>(calculatedCellDataArrays[i]);
+      ExecuteDataFunction(CompareDataArrayFunctor{}, exemplarArray.getDataType(), exemplarArray, calculatedArray);
+    }
+
+    const auto exemplarFeatureDataArrays = GetAllChildArrayDataPaths(ds, exemplarCellFeatureDataPath).value();
+    const auto calculatedFeatureDataArrays = GetAllChildArrayDataPaths(ds, destCellFeatureDataPath).value();
+    for(usize i = 0; i < exemplarFeatureDataArrays.size(); ++i)
+    {
+      const IDataArray& exemplarArray = ds.getDataRefAs<IDataArray>(exemplarFeatureDataArrays[i]);
+      const IDataArray& calculatedArray = ds.getDataRefAs<IDataArray>(calculatedFeatureDataArrays[i]);
+      ExecuteDataFunction(CompareDataArrayFunctor{}, exemplarArray.getDataType(), exemplarArray, calculatedArray);
+    }
+
+    const auto srcNewGrainDataArrays = GetAllChildArrayDataPaths(ds, srcGeomPath.createChildPath(destNewGrainDataPath.getTargetName())).value();
+    const auto calculatedNewGrainDataArrays = GetAllChildArrayDataPaths(ds, destNewGrainDataPath).value();
+    for(usize i = 0; i < srcNewGrainDataArrays.size(); ++i)
+    {
+      const IDataArray& exemplarArray = ds.getDataRefAs<IDataArray>(srcNewGrainDataArrays[i]);
+      const IDataArray& calculatedArray = ds.getDataRefAs<IDataArray>(calculatedNewGrainDataArrays[i]);
+      ExecuteDataFunction(CompareDataArrayFunctor{}, exemplarArray.getDataType(), exemplarArray, calculatedArray);
+    }
+
+    const auto srcPhaseDataArrays = GetAllChildArrayDataPaths(ds, srcGeomPath.createChildPath(destPhaseDataPath.getTargetName())).value();
+    const auto calculatedPhaseDataArrays = GetAllChildArrayDataPaths(ds, destPhaseDataPath).value();
+    for(usize i = 0; i < srcPhaseDataArrays.size(); ++i)
+    {
+      const IDataArray& exemplarArray = ds.getDataRefAs<IDataArray>(srcPhaseDataArrays[i]);
+      const IDataArray& calculatedArray = ds.getDataRefAs<IDataArray>(calculatedPhaseDataArrays[i]);
+      ExecuteDataFunction(CompareDataArrayFunctor{}, exemplarArray.getDataType(), exemplarArray, calculatedArray);
+    }
+  }
+
+  // 2D image geom
+  {
+    ResampleImageGeomFilter filter;
+    Arguments args;
+
+    DataStructure ds = LoadDataStructure(fs::path(fmt::format("{}/TestFiles/ResampleImageGeom_Exemplar.dream3d", unit_test::k_DREAM3DDataDir)));
+    DataPath srcGeomPath({"Image2dDataContainer"});
+    DataPath cellDataPath = srcGeomPath.createChildPath("Cell Data");
+    DataPath destGeomPath({srcGeomPath.getTargetName() + "_RESAMPLED"});
+    DataPath destCellDataPath = destGeomPath.createChildPath(cellDataPath.getTargetName());
+    DataPath exemplarGeoPath({"Resampled_2D_ImageGeom"});
+    DataPath exemplarCellDataPath = exemplarGeoPath.createChildPath(cellDataPath.getTargetName());
+
+    // Create default Parameters for the filter.
+    args.insertOrAssign(ResampleImageGeomFilter::k_Spacing_Key, std::make_any<VectorFloat32Parameter::ValueType>(std::vector<float32>{1, 1, 1}));
+    args.insertOrAssign(ResampleImageGeomFilter::k_RenumberFeatures_Key, std::make_any<bool>(false));
+    args.insertOrAssign(ResampleImageGeomFilter::k_RemoveOriginalGeometry_Key, std::make_any<bool>(false));
+    args.insertOrAssign(ResampleImageGeomFilter::k_SelectedImageGeometry_Key, std::make_any<DataPath>(srcGeomPath));
+    args.insertOrAssign(ResampleImageGeomFilter::k_FeatureIdsArrayPath_Key, std::make_any<DataPath>(DataPath{}));
+    args.insertOrAssign(ResampleImageGeomFilter::k_CellFeatureAttributeMatrixPath_Key, std::make_any<DataPath>(DataPath{}));
+    args.insertOrAssign(ResampleImageGeomFilter::k_NewDataContainerPath_Key, std::make_any<DataPath>(destGeomPath));
+
+    // Preflight the filter and check result
+    auto preflightResult = filter.preflight(ds, args);
+    COMPLEX_RESULT_REQUIRE_VALID(preflightResult.outputActions)
+
+    // Execute the filter and check the result
+    auto executeResult = filter.execute(ds, args);
+    COMPLEX_RESULT_REQUIRE_VALID(executeResult.result)
+
+    // check that the geometry(s) and the attribute matrixes are all there
+    const auto srcGeo = ds.getDataAs<ImageGeom>(srcGeomPath);
+    const auto destGeo = ds.getDataAs<ImageGeom>(destGeomPath);
+    const auto destCellData = ds.getDataAs<AttributeMatrix>(destCellDataPath);
+    const auto exemplarGeo = ds.getDataAs<ImageGeom>(exemplarGeoPath);
+    const auto exemplarCellData = ds.getDataAs<AttributeMatrix>(exemplarCellDataPath);
+    REQUIRE(srcGeo != nullptr);
+    REQUIRE(destGeo != nullptr);
+    REQUIRE(destCellData != nullptr);
+
+    // check the resampled geometry dimensions
+    const auto destSpacing = destGeo->getSpacing();
+    const auto destDims = destGeo->getDimensions();
+    const auto destCellDataDims = destCellData->getShape();
+
+    const auto exemplarSpacing = exemplarGeo->getSpacing();
+    const auto exemplarDims = exemplarGeo->getDimensions();
+    const auto exemplarCellDataDims = exemplarCellData->getShape();
+    REQUIRE(exemplarGeo->getOrigin() == destGeo->getOrigin());
+    REQUIRE(std::fabs(destSpacing[0] - exemplarSpacing[0]) < UnitTest::EPSILON);
+    REQUIRE(std::fabs(destSpacing[1] - exemplarSpacing[1]) < UnitTest::EPSILON);
+    REQUIRE(std::fabs(destSpacing[2] - exemplarSpacing[2]) < UnitTest::EPSILON);
+    REQUIRE(destDims[0] == exemplarDims[0]);
+    REQUIRE(destDims[1] == exemplarDims[1]);
+    REQUIRE(destDims[2] == exemplarDims[2]);
+    REQUIRE(destCellDataDims[0] == exemplarCellDataDims[0]);
+    REQUIRE(destCellDataDims[1] == exemplarCellDataDims[1]);
+    REQUIRE(destCellDataDims[2] == exemplarCellDataDims[2]);
+    REQUIRE(destCellData->getSize() == exemplarCellData->getSize());
+
+    // check the data arrays
+    const auto exemplarCellDataArrays = GetAllChildArrayDataPaths(ds, exemplarCellDataPath).value();
+    const auto calculatedCellDataArrays = GetAllChildArrayDataPaths(ds, destCellDataPath).value();
+    for(usize i = 0; i < exemplarCellDataArrays.size(); ++i)
+    {
+      const IDataArray& exemplarArray = ds.getDataRefAs<IDataArray>(exemplarCellDataArrays[i]);
+      const IDataArray& calculatedArray = ds.getDataRefAs<IDataArray>(calculatedCellDataArrays[i]);
+      ExecuteDataFunction(CompareDataArrayFunctor{}, exemplarArray.getDataType(), exemplarArray, calculatedArray);
+    }
+  }
 }
-
-// TEST_CASE("Sampling::ResampleImageGeom: Valid filter execution")
-//{
-//
-//}
-
-// TEST_CASE("Sampling::ResampleImageGeom: InValid filter execution")
-//{
-//
-//}


### PR DESCRIPTION
- Implements the remove original geometry parameter feature 
- Will copy over the rest of the data from the geometry that is not included in the resample algorithm
- Implements the ResampleImageGeometry filter unit test

Requires: https://github.com/BlueQuartzSoftware/complex/pull/345